### PR TITLE
Parameter to configure resolve_relations when fetching stories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,7 @@ With this method you can get all the stories from your space as an array of obje
 **Parameters**
 - `[options]` Object, optional.
  - [options.component] String, optional. Set this parameter with the name of a component to get just the entries made with it
+ - [options.resolve_relations] String, optional. Resolve multiple levels of content by specifying comma-separated values of `component.field_name` according to your data model.
 
 **Return**
 Promise. The response of the promise is an array of transformed entries. 

--- a/src/data.js
+++ b/src/data.js
@@ -200,6 +200,10 @@ class StoryblokTo11tyData {
         if(params && params.component) {
             request_options.query['filter_query[component][in]'] = params.component;
         }
+        // Whether to resolve relations
+        if(params && params.resolve_relations) {
+            request_options.query['resolve_relations'] = params.resolve_relations;
+        }
         // Getting the data
         let pages = await this.getData('stories', 'stories', request_options);
         if(!pages.data || pages.error) {


### PR DESCRIPTION
Fixes #1 

Adds a `resolve_relations` parameter when fetching stories. [Official Storyblok docs](https://www.storyblok.com/docs/api/content-delivery#core-resources/stories/retrieve-multiple-stories) show a `resolve_relations` parameter which allows you to fetch content recursively. It's really handy for reducing requests, and means all your data can appear in one object (e.g. a cocktail contains 5 ingredients with their own properties)